### PR TITLE
c2man issues FIXED

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -30,7 +30,7 @@
 	url = https://github.com/harfbuzz/harfbuzz.git
 [submodule "fribidi"]
 	path = fribidi
-	url = https://github.com/fribidi/fribidi.git
+	url = https://github.com/notsilverhoft/fribidi
 [submodule "pango"]
 	path = pango
 	url = https://github.com/VitoVan/pango.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -28,9 +28,6 @@
 [submodule "harfbuzz"]
 	path = harfbuzz
 	url = https://github.com/harfbuzz/harfbuzz.git
-[submodule "fribidi"]
-	path = fribidi
-	url = https://github.com/notsilverhoft/fribidi
 [submodule "pango"]
 	path = pango
 	url = https://github.com/VitoVan/pango.git
@@ -40,3 +37,6 @@
 [submodule "coi-serviceworker"]
 	path = coi-serviceworker
 	url = https://github.com/gzuidhof/coi-serviceworker.git
+[submodule "fribidi"]
+	path = fribidi
+	url = https://github.com/notsilverhoft/fribidi.git

--- a/build.sh
+++ b/build.sh
@@ -217,8 +217,7 @@ check_result
 ######################
 
 cd ${magicdir}/fribidi
-
-.ci/build-c2man.sh
+sudo chmod +rwx autogen.sh
 export PATH=$PATH:${magicdir}/fribidi/c2man/c2man-install
 
 ./autogen.sh && \

--- a/build.sh
+++ b/build.sh
@@ -218,6 +218,7 @@ check_result
 
 cd ${magicdir}/fribidi
 sudo chmod +rwx autogen.sh
+sudo chmod +rwx c2man/c2man-install/c2man
 export PATH=$PATH:${magicdir}/fribidi/c2man/c2man-install
 
 ./autogen.sh && \
@@ -262,3 +263,4 @@ embuilder build sdl2 && \
     embuilder build ogg
 
 check_result
+


### PR DESCRIPTION
I was able to put an already built c2man from Debian into Fribidi. I installed the source of the original version used for the Fribidi submodule, so there is no difference between it now, other than c2man.